### PR TITLE
Fix: Remove " Summary" suffix from Notion daily summary page titles

### DIFF
--- a/src/notion.ts
+++ b/src/notion.ts
@@ -89,7 +89,7 @@ export async function saveSummaryToNotion(
   }
   const titlePropertyName = propNames.title;
   const datePropertyName = propNames.date;
-  const title = format(targetDate, 'yyyy-MM-dd') + ' Summary';
+  const title = format(targetDate, 'yyyy-MM-dd');
 
   const existingPageId = await findExistingSummaryPage(notion, databaseId, title, titlePropertyName);
   if (existingPageId) {


### PR DESCRIPTION

### Summary

This PR removes the " Summary" suffix from the titles of daily summary pages created in Notion.  This results in cleaner titles, e.g., "2024-03-28" instead of "2024-03-28 Summary".

### Background

The current implementation appends " Summary" to the end of each daily summary page title.  This is redundant and makes the titles unnecessarily long.  Users have reported that they would prefer shorter, more concise titles.

### Changes

Modified the `saveSummaryToNotion` function to remove the string concatenation that adds  " Summary" to the `title` variable. This change affects how the title property is set when creating new daily summary pages in Notion.