### PR TITLE
feat: Support specifying date for activity summary generation

### DIFF
--- a/src/notion.ts
+++ b/src/notion.ts
@@ -25,15 +25,14 @@ async function findPropertyNames(notion: Client, databaseId: string, types: ('ti
   return names;
 }
 
-export async function fetchDailyLogs(notion: Client, databaseId: string): Promise<{ logs: LogEntry[], targetDate: Date }> {
+export async function fetchDailyLogs(notion: Client, databaseId: string, targetDate: Date): Promise<LogEntry[]> {
   const propNames = await findPropertyNames(notion, databaseId, ['title', 'created_time']);
   if (!propNames.title || !propNames.createdTime) {
     throw new Error(`Log database ${databaseId} must have one 'title' and one 'created_time' property.`);
   }
   
-  const nowInJst = toZonedTime(new Date(), TIME_ZONE);
-  const startOfJstDay = startOfDay(nowInJst);
-  const endOfJstDay = endOfDay(nowInJst);
+  const startOfJstDay = startOfDay(targetDate);
+  const endOfJstDay = endOfDay(targetDate);
 
   const response: QueryDatabaseResponse = await notion.databases.query({
     database_id: databaseId,
@@ -61,7 +60,7 @@ export async function fetchDailyLogs(notion: Client, databaseId: string): Promis
     return { content, createdAt: new Date(page.created_time) };
   });
 
-  return { logs, targetDate: nowInJst };
+  return logs;
 }
 
 async function findExistingSummaryPage(notion: Client, databaseId: string, title: string, titlePropertyName: string): Promise<string | null> {


### PR DESCRIPTION

### Summary
This change adds support for specifying the target date for activity summary generation via a `date` query parameter. This allows for generating summaries for past dates.

### Background
Currently, the activity summary is generated only for the current date. This limits the usefulness of the tool, as users may want to generate summaries for past dates to analyze their activity history or catch up on missed summaries.

### Changes
- Added a `date` query parameter to the `notionActivityLog` function.
- The `targetDate` is now determined from the `date` query parameter, or defaults to the current date if not provided.
- Updated the `fetchDailyLogs` function to accept `targetDate` as an argument.
- Updated the `saveSummaryToNotion` function to accept `targetDate` as an argument and use it in the summary page title.
- Updated logging and response messages to reflect the target date.
- Used `parseISO` and `toZonedTime` to handle date parsing and timezones correctly.