### PR TITLE
fix(notion): Ensure date queries use JST timezone

### DIFF
--- a/scripts/run-e2e-test.ts
+++ b/scripts/run-e2e-test.ts
@@ -1,5 +1,6 @@
 import { Client } from '@notionhq/client';
 import { format } from 'date-fns';
+import { toZonedTime } from 'date-fns-tz';
 import { summarizeLogs } from '../src/core';
 import { fetchDailyLogs, saveSummaryToNotion } from '../src/notion';
 import { generateSummary } from '../src/gemini';
@@ -18,9 +19,10 @@ async function runTest() {
   }
 
   try {
-    console.log(`[1/4] Fetching logs for today (JST)...`);
-    const { logs, targetDate } = await fetchDailyLogs(notion, logDatabaseId);
-    console.log(`✅ Found ${logs.length} logs for ${format(targetDate, 'yyyy-MM-dd')}.`);
+    const targetDate = toZonedTime(new Date(), 'Asia/Tokyo');
+    console.log(`[1/4] Fetching logs for today (${format(targetDate, 'yyyy-MM-dd')})...`);
+    const logs = await fetchDailyLogs(notion, logDatabaseId, targetDate);
+    console.log(`✅ Found ${logs.length} logs.`);
 
     console.log('[2/4] Categorizing logs...');
     const categorizedLogs = summarizeLogs(logs);

--- a/src/notion.test.ts
+++ b/src/notion.test.ts
@@ -26,6 +26,34 @@ MockClient.mockImplementation(() => ({
 
 const notion = new MockClient({ auth: 'test_token' });
 
+describe('fetchDailyLogs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRetrieve.mockResolvedValue({
+      properties: { 'Title': { type: 'title' }, 'Created time': { type: 'created_time' } },
+    } as any);
+    mockQuery.mockResolvedValue({ results: [] } as any);
+  });
+
+  it('should query Notion with the correct JST day boundaries', async () => {
+    // Target JST: 2025-07-20
+    const targetDate = new Date('2025-07-20T12:00:00.000Z'); // A time within the target JST day
+
+    await fetchDailyLogs(notion, 'test_db_id', targetDate);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const queryFilter = mockQuery.mock.calls[0][0].filter as any;
+
+    // Start of 2025-07-20 JST is 2025-07-19T15:00:00.000Z
+    const expectedStart = '2025-07-19T15:00:00.000Z';
+    // End of 2025-07-20 JST is 2025-07-20T14:59:59.999Z, so the 'before' query should be the start of the next day
+    const expectedEnd = '2025-07-20T15:00:00.000Z';
+
+    expect(queryFilter.and[0].created_time.on_or_after).toBe(expectedStart);
+    expect(queryFilter.and[1].created_time.before).toBe(expectedEnd); // This will fail with current code
+  });
+});
+
 describe('saveSummaryToNotion', () => {
   const summaryDatabaseId = 'test_summary_db_id';
   const summaries = { today: 'summary' };

--- a/src/notion.ts
+++ b/src/notion.ts
@@ -1,5 +1,5 @@
 import { Client } from '@notionhq/client';
-import { startOfDay, endOfDay, format } from 'date-fns';
+import { startOfDay, addDays, format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 import { PageObjectResponse, QueryDatabaseResponse, CreatePageParameters, BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
 import { LogEntry } from './core';
@@ -31,15 +31,16 @@ export async function fetchDailyLogs(notion: Client, databaseId: string, targetD
     throw new Error(`Log database ${databaseId} must have one 'title' and one 'created_time' property.`);
   }
   
-  const startOfJstDay = startOfDay(targetDate);
-  const endOfJstDay = endOfDay(targetDate);
+  const jstDate = toZonedTime(targetDate, TIME_ZONE);
+  const startOfJstDay = startOfDay(jstDate);
+  const startOfNextJstDay = startOfDay(addDays(jstDate, 1));
 
   const response: QueryDatabaseResponse = await notion.databases.query({
     database_id: databaseId,
     filter: {
       and: [
         { property: propNames.createdTime, created_time: { on_or_after: startOfJstDay.toISOString() } },
-        { property: propNames.createdTime, created_time: { before: endOfJstDay.toISOString() } },
+        { property: propNames.createdTime, created_time: { before: startOfNextJstDay.toISOString() } },
       ],
     },
   });


### PR DESCRIPTION
Previously, the Notion query for daily logs used the server's default
timezone (e.g., UTC) to determine the start and end of a day. This
caused logs from a different JST day to be included in the summary.

This commit fixes the issue by converting the target date to JST
before calculating the day's boundaries for the Notion API query.
This ensures that the log fetching is always aligned with the user's
perspective in Japan.

- Refactor: Apply JST conversion in fetchDailyLogs before date calculations.
- Test: Add a unit test to notion.test.ts to verify correct timezone handling in the query.
- Chore: Update the E2E test script to align with recent refactoring.